### PR TITLE
fix(pm): sync TOOLS.md to routing triad + add announce-and-act directive

### DIFF
--- a/propertyiq/SOUL.md
+++ b/propertyiq/SOUL.md
@@ -27,6 +27,12 @@ Cues:
 
 No silent drops. Every request gets either a clarifying question or an Issue with a routing label.
 
+## Announce and act are one step
+
+Once I decide to file (outcomes 2, 3, or 4), I run the `gh issue create` command in the same action — I don't announce "I'll file this" and stop there. Announcing without acting is a violation of "do the work" and produces the worst failure mode: Martin thinks an Issue exists when none does.
+
+If `gh issue create` fails (auth, network, schema), I report the error verbatim in Telegram and ask for guidance — I don't silently retry or fabricate an Issue number.
+
 ## When I ask back before filing
 
 I ask a single clarifying question (not a battery) when any of these hold:

--- a/propertyiq/TOOLS.md
+++ b/propertyiq/TOOLS.md
@@ -2,26 +2,31 @@
 
 ## GitHub CLI
 
-Always prefix with `GH_CONFIG_DIR=/Users/agent/.config/gh-propiq-pm`. This authenticates as the `propiq-pm` user.
+Always prefix with `GH_CONFIG_DIR=/Users/agent/.config/gh-propiq-pm`. This authenticates as the `propiq-pm` user. The prefix is mandatory on every `gh` invocation — including the examples below.
 
 Common commands PM actually uses:
 
 ```bash
-# Create an Issue from a Martin request
-gh issue create \
+# Create an Issue from a Martin request.
+# Use exactly one routing label per Issue:
+#   route:pipeline — clear, actionable pipeline work (default)
+#   route:manual   — Martin handles it himself, or it's an out-of-pipeline service
+#   route:idea     — someday/maybe, not actionable now
+# The old `needs-refinement` label is deprecated — do not use it.
+GH_CONFIG_DIR=/Users/agent/.config/gh-propiq-pm gh issue create \
   --repo property-iq/{repo} \
   --title "[title]" \
   --body-file /tmp/issue-body.md \
-  --label "needs-refinement,from:martin,p{0-3}"
+  --label "route:pipeline,from:martin,p{0-3}"   # swap route:pipeline → route:manual / route:idea per classification
 
 # List PRs awaiting Martin's review across the org
-gh pr list --search "org:property-iq is:open review-requested:@me"
+GH_CONFIG_DIR=/Users/agent/.config/gh-propiq-pm gh pr list --search "org:property-iq is:open review-requested:@me"
 
 # Read recent notifications
-gh api notifications --jq '.[] | select(.repository.owner.login == "property-iq")'
+GH_CONFIG_DIR=/Users/agent/.config/gh-propiq-pm gh api notifications --jq '.[] | select(.repository.owner.login == "property-iq")'
 
 # View a specific PR's review state
-gh pr view {N} --repo property-iq/{repo} \
+GH_CONFIG_DIR=/Users/agent/.config/gh-propiq-pm gh pr view {N} --repo property-iq/{repo} \
   --json reviews,mergeable,statusCheckRollup
 ```
 


### PR DESCRIPTION
## What

Two prompt gaps causing PM to respond in text without filing Issues:

1. **TOOLS.md showed `needs-refinement` as the default label.** That label was retired when the routing triad shipped (`route:pipeline` / `route:manual` / `route:idea`). Any command PM generated from the stale example would fail with "label not found."

2. **SOUL.md's four-outcomes section described the classification but never tied "I'll file this" to executing `gh issue create` in the same action.** Observed behavior: PM produces well-formed "I'll file" replies then stops, leaving no Issue on GitHub.

Also makes `GH_CONFIG_DIR` prefix inline on every example (was a footnote rule with no example following it, so the prefix was easy for the model to omit).

## Changes

- `propertyiq/SOUL.md` — new "Announce and act are one step" section
- `propertyiq/TOOLS.md` — routing labels replace `needs-refinement`, `GH_CONFIG_DIR` prefix on every example

## Post-merge

1. Wait for Mini heartbeat pull (≤30m)
2. Session wipe
3. Re-run Tests A/B/C via Telegram — validate on Issue URLs, not text replies