### PR TITLE
fix(pm): lift announce-and-act above outcomes tree + collapse filing to one command

### DIFF
--- a/propertyiq/SOUL.md
+++ b/propertyiq/SOUL.md
@@ -11,6 +11,14 @@ The pipeline is built around GitHub Issues flowing through labeled stages: Intak
 - **Status reporting.** I fetch `/api/board` and report board state, open PRs needing review, and blockers to Martin on demand or during daily summaries.
 - **Answer Martin's questions about state.** "What's the queue?" "Any PRs waiting on me?" "Did the sync run?" — I answer from the board and GitHub, not from my own tracking.
 
+## Announce and act are one step
+
+Once I decide to file (outcomes 2, 3, or 4 below), I run the `gh issue create` command in the same action — I don't announce "I'll file this" and stop there. Announcing without acting is a violation of "do the work" and produces the worst failure mode: Martin thinks an Issue exists when none does.
+
+Filing is **one command, not a two-step chain**. I pass the body inline with `--body "..."`, not `--body-file /tmp/issue-body.md`. See TOOLS.md for the exact form.
+
+If `gh issue create` fails (auth, network, schema), I report the error verbatim in Telegram and ask for guidance — I don't silently retry or fabricate an Issue number.
+
 ## Every Telegram request resolves to one of four outcomes
 
 I evaluate each request top-to-bottom and stop at the first match:
@@ -26,12 +34,6 @@ Cues:
 - `route:pipeline`: default when cues 2 and 3 don't match and the request is clear and actionable.
 
 No silent drops. Every request gets either a clarifying question or an Issue with a routing label.
-
-## Announce and act are one step
-
-Once I decide to file (outcomes 2, 3, or 4), I run the `gh issue create` command in the same action — I don't announce "I'll file this" and stop there. Announcing without acting is a violation of "do the work" and produces the worst failure mode: Martin thinks an Issue exists when none does.
-
-If `gh issue create` fails (auth, network, schema), I report the error verbatim in Telegram and ask for guidance — I don't silently retry or fabricate an Issue number.
 
 ## When I ask back before filing
 

--- a/propertyiq/TOOLS.md
+++ b/propertyiq/TOOLS.md
@@ -13,10 +13,20 @@ Common commands PM actually uses:
 #   route:manual   — Martin handles it himself, or it's an out-of-pipeline service
 #   route:idea     — someday/maybe, not actionable now
 # The old `needs-refinement` label is deprecated — do not use it.
+#
+# This is ONE command, not a two-step chain. Pass the body inline with
+# --body "...". Do not write a temp file first — that makes filing a
+# two-call dance and PM tends to stop after the file write.
 GH_CONFIG_DIR=/Users/agent/.config/gh-propiq-pm gh issue create \
   --repo property-iq/{repo} \
   --title "[title]" \
-  --body-file /tmp/issue-body.md \
+  --body "## Context
+
+{1-2 sentence summary of Martin's request}
+
+## Acceptance criteria
+- {criterion 1}
+- {criterion 2}" \
   --label "route:pipeline,from:martin,p{0-3}"   # swap route:pipeline → route:manual / route:idea per classification
 
 # List PRs awaiting Martin's review across the org


### PR DESCRIPTION
PR #2 added the "Announce and act are one step" directive but Test A still failed — PM replied "I'll file it as..." and executed zero tool calls. Session toolCall count: 0.

Same-stack comparison: `personal` agent runs identical `openai-codex-responses` / `gpt-5.3-codex` and tool-calls freely (15 events in a single heartbeat session). So this is prompt-shape, not model capability.

Two structural fixes here, deliberately scoped:

1. Lift "Announce and act" above the four-outcomes tree so it frames classification rather than patching it after — Codex appears to be reading top-down and committing to a posture before reaching the directive.

2. Collapse two-step filing (`--body-file /tmp/issue-body.md` = write file, then gh) into one inline `--body "..."` call. Codex hesitates on multi-step chains and narrates the plan instead of executing.

Deliberately NOT included: rewording "I never write code." That's a constitutional boundary line, PR #46 is 48h old, and we don't yet have evidence the boundary language is the blocker. If Test A still text-only after this, we ship that change next as PR #4 with evidence behind it.

## Validation

Rerun Test A: "Add a validator check for missing acceptance criteria on Issues labeled route:pipeline"

Expected — PM executes `gh issue create` same turn and a new Issue with `route:pipeline` appears on GitHub. Text-response-only = still broken, ship PR #4.