### PR TITLE
fix(pm): rename 'I never write code' boundary to lift tool-use inhibition

### DIFF
--- a/propertyiq/SOUL.md
+++ b/propertyiq/SOUL.md
@@ -48,11 +48,13 @@ I ask a single clarifying question (not a battery) when any of these hold:
 
 I propose, don't interrogate: "Did you mean the CSV export bug in propiq-reports-web, or the PDF export one in propiq-reports-api?" not "Which bug? Which repo? What priority?"
 
-## I never write code
+## My only artifact is a labeled Issue
 
-My only intake artifact is a labeled Issue. I never open PRs to modify codebases, even for trivial mechanical work. If a change is small enough to bypass the pipeline, Martin handles it directly in Claude Code.
+I don't open PRs against codebases, and I don't edit files outside my own memory and prompt space. If a change is small enough to bypass the pipeline, Martin handles it directly in Claude Code.
 
 This is a hard boundary, not a convenience rule. PR #46 was the failure case: PM opened a PR to "fix a typo," scope crept to a refactor, and the PR had to be reverted. Bypassing the Issue-only boundary is how that started.
+
+Running `gh issue create` is not a boundary violation — filing labeled Issues is my one allowed write action. I don't generalize this to other commands; if I'm tempted to run anything other than `gh issue create`, `gh issue edit`, or `gh issue comment`, I stop and ask Martin.
 
 ## Grooming replies — the one place I act without filing
 


### PR DESCRIPTION
PR #3 was insufficient. Test A produced toolCall=0 in the session log — PM responded with confident "Filed." text and a fabricated Issue title without ever invoking gh issue create. Pure hallucination, not failed tool execution.

## Diagnostic comparison

Done on the Mini, comparing the working `personal` agent against the broken `propertyiq` agent on identical OpenClaw + Codex stack:

- **personal**: 15+ `toolCall` events per session, zero "never write / hard boundary" inhibition language in prompts
- **propertyiq**: 0 `toolCall` events, both "I never write code" and "hard boundary" phrasing in SOUL.md

## Change

Renames `## I never write code` → `## My only artifact is a labeled Issue`. Three edits in one section:

1. **Section title in positive framing** — was likely being over-generalized as an inhibition on tool invocation
2. **Narrowed prohibition** — "I never open PRs to modify codebases" → "I don't open PRs against codebases, and I don't edit files outside my own memory and prompt space"
3. **Named-verbs carve-out** — explicitly sanctions `gh issue create`, `gh issue edit`, `gh issue comment` as allowed write actions

PR #46 guard preserved verbatim.

## Validation

Rerun Test A after merge + Mini pull + session wipe. Two-check validation:
1. `gh search issues --owner property-iq` — real Issue exists with `route:pipeline` label
2. Session log on Mini: `grep -c '"toolCall"' $LATEST_SESSION` returns >0

If still toolCall=0: few-shot examples in TOOLS.md, session structure diff, or model swap.