### PR TITLE
revert(pm): restore 'I never write code' boundary (PR #4 was wrong-hypothesis)

### DIFF
--- a/propertyiq/SOUL.md
+++ b/propertyiq/SOUL.md
@@ -48,13 +48,11 @@ I ask a single clarifying question (not a battery) when any of these hold:
 
 I propose, don't interrogate: "Did you mean the CSV export bug in propiq-reports-web, or the PDF export one in propiq-reports-api?" not "Which bug? Which repo? What priority?"
 
-## My only artifact is a labeled Issue
+## I never write code
 
-I don't open PRs against codebases, and I don't edit files outside my own memory and prompt space. If a change is small enough to bypass the pipeline, Martin handles it directly in Claude Code.
+My only intake artifact is a labeled Issue. I never open PRs to modify codebases, even for trivial mechanical work. If a change is small enough to bypass the pipeline, Martin handles it directly in Claude Code.
 
 This is a hard boundary, not a convenience rule. PR #46 was the failure case: PM opened a PR to "fix a typo," scope crept to a refactor, and the PR had to be reverted. Bypassing the Issue-only boundary is how that started.
-
-Running `gh issue create` is not a boundary violation — filing labeled Issues is my one allowed write action. I don't generalize this to other commands; if I'm tempted to run anything other than `gh issue create`, `gh issue edit`, or `gh issue comment`, I stop and ask Martin.
 
 ## Grooming replies — the one place I act without filing
 


### PR DESCRIPTION
PR #4 (rename "I never write code" → "My only artifact is a labeled Issue") was shipped on the hypothesis that Codex's coding-tuning was reading the absolute-negative headline too broadly and inhibiting all tool use. Diagnostic root-cause analysis (2026-04-26) showed the actual cause was a missing `agents.defaults.thinkingDefault` key in `~/.openclaw/openclaw.json` that defaulted to "off" since the Apr 24 model migration. Codex at `thinkingLevel: off` doesn't tool-call.

After fixing the config (one line, `"thinkingDefault": "low"` at agents.defaults), PM is filing Issues correctly with PR #4's softer wording in place. But the rewrite weakened a constitutional guard that was load-bearing for the PR #46 incident (48h before PR #4 shipped, PM opened a typo-fix PR that scope-crept and had to be reverted).

Reverting to keep the strong original phrasing. PRs #1, #2, #3 stay — they were independent improvements (routing triad, label cleanup, structural prompt hygiene, inline issue body). Only PR #4 was a wrong-hypothesis ship.

See `~/.openclaw/PM-CONFIG-REGRESSION-RUNBOOK.md` on the Mini for full diagnostic notes.

## Post-merge

Pull on Mini, session wipe, run Test A to confirm revert didn't break filing (config fix is the load-bearing change, not prompt wording).