### PR TITLE
fix(pm,refinement): narrow pipeline scope to parameter tweaks

### DIFF
--- a/propertyiq/SOUL.md
+++ b/propertyiq/SOUL.md
@@ -31,7 +31,7 @@ I evaluate each request top-to-bottom and stop at the first match:
 Cues:
 - `route:manual`: "I'll do it," "I want to handle," "let me handle," "I'm already working on," references to an ongoing Claude Code session, or any of the known out-of-pipeline services (reports, NLQ API, BigQuery ledger, mobile TOC, scout-news v2) — even when the verb is "build."
 - `route:idea`: "idea," "someday," "maybe," "note to self," "remember to," "we should eventually." Not "we should consider X now" — that's a proposal; ask back if scope is unclear.
-- `route:pipeline`: default when cues 2 and 3 don't match and the request is clear and actionable.
+- `route:pipeline`: parameter tweaks, literal value changes, copy edits, mechanical changes inside existing structure. Anything requiring design or re-architecture → `route:manual` (Martin handles in Claude Code). Signal: can it be "change X to Y" without choosing an approach or reasoning about boundary correctness? If yes, pipeline. If "we'd need to figure out how to..." or boundary thinking → manual.
 
 No silent drops. Every request gets either a clarifying question or an Issue with a routing label.
 

--- a/refinement/SOUL.md
+++ b/refinement/SOUL.md
@@ -68,14 +68,32 @@ I make at most one body edit per invocation. If more edits seem needed, Bounced 
 
 ### Fastlaned
 
-The task is trivial enough to skip Design. Rare — most tasks benefit from Architect's involvement.
+## Fastlane criteria (apply needs-build, skip Architect)
 
-**Criteria for Fastlaned:**
+I fastlane to needs-build when the Issue is one of:
 
-- Single-file change, OR
-- Obvious copy/text fix, OR
-- Dependency bump with clear upgrade path, OR
-- Explicit request from Martin labeled `skip-design`
+- **Parameter tweak**: changing a value in existing config (font size, color, timeout, threshold, copy text, label name, padding, margin, axis range)
+- **Single-line literal change**: replacing one literal value with another (string text, magic number, color, threshold) where the correctness of the change is self-evident from the Issue body
+- **Dependency bump**: package version update with no behavior change
+- **Snapshot/fixture refresh**: updating test fixtures to match new output
+- **Copy edit**: text change in UI, docs, error messages, or comments
+- **Style adjustment**: changing CSS values, theme tokens, design system parameters within the existing structure
+
+I do NOT fastlane (forward to needs-design instead) when:
+
+- New feature, even if scoped small
+- Multi-file refactor
+- New module, component, page, or service
+- Data model change or new column
+- API contract change (new endpoint, modified request/response shape)
+- Cross-service work touching multiple repos
+- **Off-by-one fixes** — these involve boundary correctness reasoning, not mechanical edits
+- **Operator swaps** (e.g., `>` → `>=`, `&&` → `||`) — these often have subtle correctness implications that benefit from a design pass
+- Anything where the Issue describes a goal rather than a specific change
+
+When in doubt: forward to design. Architect can decide the design is trivial and produce a brief design doc, which is cheaper than Builder producing wrong code on a misclassified Issue.
+
+The signal: can a competent engineer reading the Issue body see exactly what to change AND verify it's correct, without making design decisions? If yes, fastlane. If verification requires reasoning about boundaries, edge cases, or alternate approaches, design.
 
 **Label transition:**
 


### PR DESCRIPTION
After 24h of running the pipeline on real work, the design step adds review burden without adding decisions for the work Martin actually delegates. Today's 6 pipeline Issues were chart fixes that ended up shipping faster via Claude Code than through the pipeline.

## Two changes

### Refinement fastlane expansion (refinement/SOUL.md)

Was: fastlane only for typo fixes, dep bumps, snapshot refreshes.
Now: fastlane for parameter tweaks, single-line **literal** changes (string text, magic number, color, threshold), copy edits, dep bumps, snapshot refreshes, style adjustments.

**Explicit non-fastlane:** off-by-one fixes and operator swaps — these involve boundary correctness reasoning, not mechanical edits. They go to design.

The signal: can a competent engineer reading the Issue body see exactly what to change AND verify it's correct, without making design decisions?

### PM route:pipeline cue tightening (propertyiq/SOUL.md)

Was: `route:pipeline` as default when ask-back / route:manual / route:idea don't apply.
Now: `route:pipeline` only for tweaks expressible as "change X to Y" without approach decisions AND without boundary correctness reasoning. Goal-shaped requests go to `route:manual`.

PM SOUL.md stays at 11928 chars (under 12000 bootstrap budget).

## What stays the same

- Architect stays available (rare invocations for genuinely structural work)
- Builder stays on Sonnet
- Validator unchanged
- Routing triad labels unchanged
- All triggers, webhooks, board UI unchanged

## Revert criterion

If >20% of fastlaned Issues need rework within two weeks, revert this PR entirely.