### PR TITLE
feat(chart-qa): Phase E REST-first audit + sweep-mode async dispatch

### DIFF
--- a/propertyiq/SOUL.md
+++ b/propertyiq/SOUL.md
@@ -95,7 +95,13 @@ I do NOT validate on `/chart/{intent}` standalone paths on `reports.propertyiq.a
 
 ### What I check
 
-For each chart visible on the surface:
+I have two audit paths and the right path depends on the target. Per the chart-qa skill:
+
+- **Single chart with a known intent + entities** → REST first. I run `propertyiq/skills/chart-qa/audit_via_rest.sh` against `POST /charts/audit`, which evaluates Layer 1 (existence), Layer 2a (layout), and Layer 3 (style) in under a second. Add `--include-image` only when I specifically need Layer 2b vision review (renders + uploads PNG; ~3–8s).
+- **Page or surface audit** (rendered report, playground, multiple charts in context) → Playwright + dual-viewport screenshots, per the steps below. The Playwright path catches surface-level issues the REST endpoint can't see: cross-chart layout, banners, console errors, viewport breakage.
+- **Sweep of more than 3 charts** → REST in parallel (5 concurrent max), async dispatch with one Telegram acknowledgment up front and one summary message at the end. Don't spam findings in real time.
+
+For surface / page audits, for each chart visible on the surface:
 
 - **State enumeration.** If the chart has tabs, period toggles (Monthly/Quarterly/Yearly), segment selectors, or comparison toggles, I screenshot each visible state — not just the default load. Default-only is a regression of the audit.
 - **Dual viewport.** Desktop (1280×800) AND mobile (390×844, iPhone 14 Pro class). One viewport breaking = breakage.

--- a/propertyiq/skills/chart-qa/SKILL.md
+++ b/propertyiq/skills/chart-qa/SKILL.md
@@ -4,6 +4,18 @@
 
 Validate rendered charts against the authoritative contract at `propiq-docs/charts/spec.yaml`. Every value PM checks comes from the resolved spec — never from memory, never from inline prompt values.
 
+## Two audit paths
+
+PM has two audit paths. **Pick the one that matches the audit target**, not your habit:
+
+| Target | Path | Why |
+|---|---|---|
+| **Single chart** with a known intent + entities | **REST first** (`audit_via_rest.sh`) | Sub-second when no vision needed; ~3–8s with vision. No screenshot, no Playwright. |
+| **Page** (rendered report or playground) with multiple charts in context | **Playwright + screenshots** (steps 1–3 below) | Catches surface-level issues: cross-chart layout, banners, console errors, viewport breakage. |
+| **Sweep** of N > 3 charts | **REST in parallel, async** (see "Sweep-mode dispatch" below) | Avoids serial round-trips; bundles findings into one Telegram summary. |
+
+REST-first means: most single-chart audits skip the screenshot path entirely. Playwright is reserved for surface audits and Layer 2b vision review.
+
 ## Pre-audit: fetch the spec
 
 Before any evaluation, run:
@@ -18,7 +30,42 @@ This writes:
 
 **If the fetch fails, abort the audit.** Report the error verbatim to Martin. Never fall back to memorized or cached values — proceeding with stale data defeats the purpose of the spec contract.
 
-## Evaluation flow
+## REST-first single-chart audit
+
+When the target is one chart with a known intent and entities (the common case), use the REST path:
+
+```bash
+# Synchronous, sub-second. Layers: existence + layout + style. No vision.
+echo '{"render_request": {"intent": "trend", "metric": "price", "entities": [{"type": "area", "identifier": "dubai-marina"}]}}' \
+  | bash propertyiq/skills/chart-qa/audit_via_rest.sh --no-vision \
+       --output "$WORKSPACE_TMP/audit_result.json"
+
+# With Layer 2b vision audit (renders + uploads PNG; ~3–8s).
+echo '{"render_request": {...}}' \
+  | bash propertyiq/skills/chart-qa/audit_via_rest.sh --include-image \
+       --output "$WORKSPACE_TMP/audit_result.json"
+```
+
+The script's output is the `AuditResult` JSON: `passed`, `violations[]`, `summary`, `audit_coverage`. Each violation carries a `layer` field (`existence` / `layout` / `style` / `visual`). Exit 0 iff `passed: true`.
+
+If the chart isn't already rendered (you have a `ChartRequest` rather than a `chart_response.config`), pass `render_request` and the API renders + audits in one round-trip.
+
+## Sweep-mode dispatch
+
+When auditing N > 3 charts (e.g. *"audit all charts in the April market report"*):
+
+1. **Acknowledge immediately on Telegram**: *"Auditing N charts; will report back when complete."*
+2. **Run audits in parallel**, bounded at 5 concurrent (matches `chart_concurrency` elsewhere in the stack). Use `xargs -P 5` or a small async wrapper.
+3. **Post a follow-up Telegram message** with a structured summary: per-chart pass/fail, per-layer counts, top violations. Don't surface findings in real time — batch them.
+4. **For each chart with violations**, file Issues per the drift-classification mapping below.
+
+For ≤ 3 charts, dispatch synchronously and post findings inline.
+
+For single-chart audits where Martin needs sub-second turnaround, use `--no-vision`.
+
+## Evaluation flow (page-level / surface audit / Layer 2b)
+
+When the target is a full page or you specifically need Layer 2b vision review on rendered output, follow steps 1–6 below. This path uses Playwright + screenshots.
 
 ### 1. Identify the surface
 
@@ -84,6 +131,19 @@ For each deviation found, determine whether it's:
 
 3. **Ambiguous** — unclear which side is wrong (e.g., partial migration in flight).
    - Do not file. Surface to Martin in Telegram with both possibilities listed.
+
+#### Drift-classification by layer
+
+When the violation came from REST, the `layer` field on each Violation tightens routing. Drift-classification is preserved per finding — there is no blanket route.
+
+| Layer | Typical drift routing |
+|---|---|
+| **`existence` (Layer 1)** | Drift-classify case-by-case. Most route to `propiq-charts-api` (chart contract issue) or upstream (`propiq-data-api`, `propiq-docs`) when the data itself is missing. Empty datasets often indicate a data-api gap, not a charts-api bug. |
+| **`layout` (Layer 2a)** | Drift-classify between `propiq-charts-api` (sizing logic), `propiq-docs/charts/spec.yaml` (rule thresholds), and `app/styling/themes/base.yaml` (token values). A predicate firing at high false-positive rate is itself a signal — file against `propiq-docs` to revisit the threshold. |
+| **`visual` (Layer 2b)** | Always `propiq-charts-api` or `propiq-charts-img` — vision findings are about rendering output, never about spec drift. |
+| **`style` (Layer 3)** | Existing routing preserved. Spec-rule predicates → `propiq-charts-api` (runtime regression) or `propiq-docs` (spec lag). |
+
+When the violation came from a screenshot evaluation (Playwright path), the legacy classification rules above apply unchanged.
 
 ### 6. Report
 

--- a/propertyiq/skills/chart-qa/audit-finding-template.md
+++ b/propertyiq/skills/chart-qa/audit-finding-template.md
@@ -14,12 +14,16 @@ Use this template for the Issue body when filing a chart-audit finding. Every fi
 - `<rule_id>` — <paraphrase the rule from guidelines.md>
 - (additional rules if multiple)
 
+## Layer
+
+`<existence | layout | visual | style>` — populated from the `layer` field on the Violation when the audit ran via REST. Omit when the finding came from a screenshot-only Playwright evaluation (legacy path).
+
 ## Context
 
 - **Spec version:** <from spec-manifest.txt>
-- **Surface:** <url>
-- **Viewport:** <desktop / mobile / both>
-- **State:** <which tab/toggle was active>
+- **Surface:** <url, OR "REST audit" when no rendered surface>
+- **Viewport:** <desktop / mobile / both, OR "n/a" for REST audits>
+- **State:** <which tab/toggle was active, OR omit for REST audits>
 
 ## Evidence
 

--- a/propertyiq/skills/chart-qa/audit_via_rest.sh
+++ b/propertyiq/skills/chart-qa/audit_via_rest.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# audit_via_rest.sh — call POST /charts/audit and emit the result.
+#
+# Phase E (Multi-layer chart audit, design §4 Phase E item 2). REST-first
+# audit path that doesn't require a screenshot. The Playwright + dual-
+# viewport flow is preserved for Layer 2b vision audits and full-surface
+# (page-level) audits — see SKILL.md.
+#
+# Inputs:
+#   stdin — JSON request body. Either:
+#     {"config": {...Chart.js config...}, "intent": "trend", "mode": "web"}
+#   or:
+#     {"render_request": {...ChartRequest...}}
+#
+# Flags:
+#   --no-vision      Force REST-only synchronous path under 1 second.
+#                    Layers: existence, layout, style. Default.
+#   --include-image  Include Layer 2b vision audit (renders + uploads PNG;
+#                    expect ~3-8 seconds). Layers: existence, layout, style,
+#                    visual.
+#   --layers CSV     Override the layer list explicitly. Comma-separated,
+#                    e.g. --layers existence,style. Wins over --no-vision /
+#                    --include-image.
+#   --url URL        Override charts-api base URL. Default reads
+#                    $CHARTS_API_URL or falls back to the production URL.
+#   --output PATH    Write the full JSON response to PATH (in addition to
+#                    stdout). Useful when capturing in $WORKSPACE_TMP.
+#
+# Outputs:
+#   stdout — the AuditResult JSON from POST /charts/audit (always emitted,
+#            even on non-zero exit, so the caller can introspect violations).
+#   stderr — diagnostic messages.
+#
+# Exit codes:
+#   0 — audit completed and passed:true (zero error-severity violations).
+#   1 — audit completed but passed:false (violations present).
+#   2 — request failed (HTTP error, bad input, network failure).
+#
+# Auth:
+#   Uses $CHARTS_AUDIT_TOKEN as a bearer token if set (matches the
+#   MCP_TOKEN_* convention from gap analysis Cat C). When unset, sends
+#   no Authorization header — fine if charts-api doesn't enforce auth on
+#   /charts/audit yet.
+
+set -euo pipefail
+
+DEFAULT_URL="https://propiq-charts-api-429012647952.me-central1.run.app"
+CHARTS_URL="${CHARTS_API_URL:-$DEFAULT_URL}"
+
+LAYERS_DEFAULT="existence,layout,style"
+LAYERS_WITH_VISION="existence,layout,style,visual"
+LAYERS=""
+
+OUTPUT_PATH=""
+LAYER_OVERRIDE=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --no-vision)
+            LAYERS="$LAYERS_DEFAULT"
+            shift
+            ;;
+        --include-image)
+            LAYERS="$LAYERS_WITH_VISION"
+            shift
+            ;;
+        --layers)
+            LAYER_OVERRIDE="$2"
+            shift 2
+            ;;
+        --url)
+            CHARTS_URL="$2"
+            shift 2
+            ;;
+        --output)
+            OUTPUT_PATH="$2"
+            shift 2
+            ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -50
+            exit 0
+            ;;
+        *)
+            echo "audit_via_rest: unknown flag: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+# Layer resolution: explicit override wins. Otherwise use --no-vision /
+# --include-image. Otherwise default to no-vision (sub-second path).
+if [ -n "$LAYER_OVERRIDE" ]; then
+    LAYERS="$LAYER_OVERRIDE"
+elif [ -z "$LAYERS" ]; then
+    LAYERS="$LAYERS_DEFAULT"
+fi
+
+# Read stdin into a temp file so we can validate it's JSON before sending.
+INPUT_FILE="$(mktemp)"
+trap 'rm -f "$INPUT_FILE"' EXIT
+cat > "$INPUT_FILE"
+
+if [ ! -s "$INPUT_FILE" ]; then
+    echo "audit_via_rest: empty stdin — pass a JSON request body" >&2
+    exit 2
+fi
+
+# Validate stdin is JSON. jq is the standard tool here; if missing, fail
+# loudly rather than sending a malformed body.
+if ! command -v jq >/dev/null 2>&1; then
+    echo "audit_via_rest: jq is required (used for stdin validation)" >&2
+    exit 2
+fi
+
+if ! jq empty "$INPUT_FILE" >/dev/null 2>&1; then
+    echo "audit_via_rest: stdin is not valid JSON" >&2
+    exit 2
+fi
+
+# Inject layers into the body. The route accepts layers as a body field;
+# preserve every other field the caller passed.
+LAYERS_JSON_ARRAY="$(printf '%s' "$LAYERS" \
+    | tr ',' '\n' \
+    | jq -R . \
+    | jq -s .)"
+
+REQUEST_BODY="$(jq --argjson layers "$LAYERS_JSON_ARRAY" '. + {layers: $layers}' "$INPUT_FILE")"
+
+# Build curl invocation. Bearer token only when the env var is set.
+CURL_AUTH=()
+if [ -n "${CHARTS_AUDIT_TOKEN:-}" ]; then
+    CURL_AUTH=(-H "Authorization: Bearer $CHARTS_AUDIT_TOKEN")
+fi
+
+RESPONSE_FILE="$(mktemp)"
+trap 'rm -f "$INPUT_FILE" "$RESPONSE_FILE"' EXIT
+
+HTTP_STATUS="$(curl -sS \
+    -X POST \
+    -H "Content-Type: application/json" \
+    "${CURL_AUTH[@]}" \
+    -o "$RESPONSE_FILE" \
+    -w "%{http_code}" \
+    --max-time 30 \
+    "$CHARTS_URL/charts/audit" \
+    --data-binary "$REQUEST_BODY" \
+    || echo "0")"
+
+if [ "$HTTP_STATUS" = "0" ]; then
+    echo "audit_via_rest: network failure calling $CHARTS_URL/charts/audit" >&2
+    cat "$RESPONSE_FILE" >&2 || true
+    exit 2
+fi
+
+if [ "$HTTP_STATUS" -ge 400 ]; then
+    echo "audit_via_rest: HTTP $HTTP_STATUS from $CHARTS_URL/charts/audit" >&2
+    cat "$RESPONSE_FILE" >&2 || true
+    exit 2
+fi
+
+# Always emit the response on stdout.
+cat "$RESPONSE_FILE"
+
+# Optionally also write it to a file (callers commonly want this in
+# $WORKSPACE_TMP for downstream Issue-filing).
+if [ -n "$OUTPUT_PATH" ]; then
+    cp "$RESPONSE_FILE" "$OUTPUT_PATH"
+fi
+
+# Exit 0 iff passed:true. Anything else (including missing field) → 1.
+PASSED="$(jq -r '.passed // false' "$RESPONSE_FILE")"
+if [ "$PASSED" = "true" ]; then
+    exit 0
+fi
+exit 1


### PR DESCRIPTION
## Summary

Extends the existing \`chart-qa\` skill to use \`POST /charts/audit\` as the primary audit path for single-chart audits, per multi-layer chart audit design Phase E. The Playwright + dual-viewport screenshot path is preserved for surface audits and Layer 2b vision review.

Phase A's audit-layer abstraction is live on \`propiq-charts-api/main\` (PR #276 merged), so the REST surface for layer-aware audits is available.

## What changed

- **New \`audit_via_rest.sh\` helper** — single shell script with structured stdin/stdout. Flags: \`--no-vision\` (default; sub-second), \`--include-image\` (adds Layer 2b vision; ~3–8s), \`--layers CSV\` (explicit override), \`--url\`, \`--output PATH\`. Exit 0 iff \`passed: true\`. Bearer-token auth via \`\$CHARTS_AUDIT_TOKEN\` matching the \`MCP_TOKEN_*\` Secret Manager convention (per design §10 item 2 default).
- **\`SKILL.md\` restructured** with three audit paths: single chart → REST first; page/surface/Layer 2b → Playwright; sweep of >3 charts → REST in parallel with async Telegram dispatch.
- **Drift-classification by layer** subsection added to \`SKILL.md\` mapping each layer (\`existence\` / \`layout\` / \`visual\` / \`style\`) to its drift-routing convention. Routing per-finding is preserved — there's no blanket route to \`propiq-charts-api\`.
- **\`audit-finding-template.md\`** gains a \`**Layer:**\` field populated from the Violation's \`layer\` attribute on REST-path findings.
- **\`SOUL.md\` "What I check"** reflects the path fork.

## Sweep-mode async dispatch

When auditing >3 charts:
1. Acknowledge immediately on Telegram (\"Auditing N charts; will report back.\")
2. Run audits in parallel, bounded at 5 concurrent.
3. Post one structured summary message at the end — don't surface findings in real time.
4. File Issues per drift classification per finding.

For ≤3 charts, dispatch synchronously inline. For single-chart with \`--no-vision\`, response is sub-second.

## Auth pattern

Default per design §10 item 2: bearer token via \`\$CHARTS_AUDIT_TOKEN\` env var, provisioned alongside \`MCP_TOKEN_OPENCLAW\` in Secret Manager. Script sends the token only when the env var is set; charts-api can enforce or not enforce auth on \`/charts/audit\` independently. Re-litigable at Phase E kickoff only if the endpoint ends up requiring no auth at all.

## Test plan

- [x] \`lint_no_hardcoded_values.sh\` passes (no hardcoded PIQ-STYLE values introduced).
- [x] \`audit_via_rest.sh\` parses \`--help\` correctly.
- [x] Empty stdin → exit 2 with stderr message.
- [x] Malformed JSON → exit 2 with stderr message.
- [ ] Live smoke test against production charts-api: \`echo '{\"render_request\": {\"intent\": \"trend\", \"metric\": \"price\", \"entities\": [{\"type\": \"area\", \"identifier\": \"dubai-marina\"}]}}' | bash propertyiq/skills/chart-qa/audit_via_rest.sh --no-vision\` — needs Mac-mini operator validation.
- [ ] Sweep-mode UX validation on Mac mini per design §11 (5-chart audit completes within 60s end-to-end).

## What this doesn't do

- Doesn't change the spec-fetch path (\`fetch_spec.sh\` unchanged).
- Doesn't replace the Playwright path — surface audits still use it.
- Doesn't autonomously file Issues — finding routing per layer is documented but the agent still surfaces findings to Martin first per existing boundaries.

## Design

[\`propiq-docs/designs/chart-audit-program/IMPLEMENTATION-NOTES.md\` §4 Phase E](https://github.com/property-iq/propiq-docs/blob/main/designs/chart-audit-program/IMPLEMENTATION-NOTES.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)