### PR TITLE
fix(chart-qa): empty-array nounset crash in audit_via_rest.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,3 +64,22 @@ jobs:
 
       - name: Lint for hardcoded values
         run: bash scripts/lint_no_hardcoded_values.sh
+
+  shellcheck:
+    name: ShellCheck on skill helpers
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install shellcheck
+        run: sudo apt-get install -y shellcheck
+
+      - name: ShellCheck on chart-qa helpers
+        run: |
+          # Per Tranche A.5 of the chart-qa signal-restoration plan
+          # (working/design/propiq-charts-api_2026-05-04_chart-qa-signal-restoration.md):
+          # the audit_via_rest.sh helper crashed under `set -u` on bash 3.2
+          # when CHARTS_AUDIT_TOKEN was unset (empty-array expansion).
+          # Run shellcheck on every shell helper to catch this class of bug.
+          find propertyiq/skills -name '*.sh' -print0 \
+            | xargs -0 -r shellcheck --severity=warning

--- a/propertyiq/skills/chart-qa/audit_via_rest.sh
+++ b/propertyiq/skills/chart-qa/audit_via_rest.sh
@@ -127,6 +127,11 @@ LAYERS_JSON_ARRAY="$(printf '%s' "$LAYERS" \
 REQUEST_BODY="$(jq --argjson layers "$LAYERS_JSON_ARRAY" '. + {layers: $layers}' "$INPUT_FILE")"
 
 # Build curl invocation. Bearer token only when the env var is set.
+# bash 3.2 (system bash on macOS) treats empty-array expansion as
+# "unbound variable" under `set -u` even with `[@]`. The
+# `${arr[@]+"${arr[@]}"}` idiom is the portable workaround: it expands
+# to nothing when the array is empty/unset, and to the array elements
+# otherwise. See https://stackoverflow.com/q/7577052 — same issue.
 CURL_AUTH=()
 if [ -n "${CHARTS_AUDIT_TOKEN:-}" ]; then
     CURL_AUTH=(-H "Authorization: Bearer $CHARTS_AUDIT_TOKEN")
@@ -138,7 +143,7 @@ trap 'rm -f "$INPUT_FILE" "$RESPONSE_FILE"' EXIT
 HTTP_STATUS="$(curl -sS \
     -X POST \
     -H "Content-Type: application/json" \
-    "${CURL_AUTH[@]}" \
+    ${CURL_AUTH[@]+"${CURL_AUTH[@]}"} \
     -o "$RESPONSE_FILE" \
     -w "%{http_code}" \
     --max-time 30 \


### PR DESCRIPTION
## Summary
- **Tranche A.5** of the chart-qa signal-restoration plan ([finding F9](../../working/design/propiq-charts-api_2026-05-04_chart-qa-signal-restoration.md)). On bash 3.2 (system bash on macOS) under `set -u`, expanding an empty array via `"${arr[@]}"` raises *"unbound variable"* — older bash treats empty arrays as unset. The script crashed when `CHARTS_AUDIT_TOKEN` was unset because `CURL_AUTH=()` stayed empty and `"${CURL_AUTH[@]}"` tripped.
- **Fix:** use the `${arr[@]+"${arr[@]}"}` idiom — expands to nothing if the array is empty/unset, otherwise expands the elements. Standard portable workaround for this exact bash 3.2 quirk.
- **Bonus:** adds a `shellcheck` CI job that runs `--severity=warning` across all `propertyiq/skills/**/*.sh` helpers (currently `chart-qa/audit_via_rest.sh` + `chart-qa/fetch_spec.sh`; future helpers picked up automatically). Both clean today.

## Test plan
- [x] Reproduced the bug locally on bash 3.2.57 (arm64-apple-darwin24): script crashed at `${CURL_AUTH[@]}` expansion.
- [x] After fix: script reaches curl with `CHARTS_AUDIT_TOKEN` unset and set; both paths return the AuditResult and exit 0.
- [x] `shellcheck --severity=warning` clean on both helpers.
- [ ] CI green (including new shellcheck job).