### PR TITLE
feat(chart-qa): exit code + template fields off error_count (Tranche A.4 step 2)

### DIFF
--- a/propertyiq/skills/chart-qa/SKILL.md
+++ b/propertyiq/skills/chart-qa/SKILL.md
@@ -46,7 +46,7 @@ echo '{"render_request": {...}}' \
        --output "$WORKSPACE_TMP/audit_result.json"
 ```
 
-The script's output is the `AuditResult` JSON: `passed`, `violations[]`, `summary`, `audit_coverage`. Each violation carries a `layer` field (`existence` / `layout` / `style` / `visual`). Exit 0 iff `passed: true`.
+The script's output is the `AuditResult` JSON: `error_count`, `warning_count`, `severity_breakdown`, `violations[]`, `summary`, `audit_coverage`, plus the deprecated `passed` field for backward compat. Each violation carries a `layer` field (`existence` / `layout` / `style` / `visual`). **Exit 0 iff `error_count == 0`** (no error-severity findings); warnings do not change the exit code. The `passed` field is deprecated — read `error_count` directly when you need the gate.
 
 If the chart isn't already rendered (you have a `ChartRequest` rather than a `chart_response.config`), pass `render_request` and the API renders + audits in one round-trip.
 

--- a/propertyiq/skills/chart-qa/audit-finding-template.md
+++ b/propertyiq/skills/chart-qa/audit-finding-template.md
@@ -18,6 +18,12 @@ Use this template for the Issue body when filing a chart-audit finding. Every fi
 
 `<existence | layout | visual | style>` — populated from the `layer` field on the Violation when the audit ran via REST. Omit when the finding came from a screenshot-only Playwright evaluation (legacy path).
 
+## Audit summary
+
+- **Error count:** `<error_count>` — populated from `AuditResult.error_count` (Tranche A.4 step 1). Read this for blocking decisions; the deprecated `passed` flag is no longer load-bearing in this template.
+- **Warning count:** `<warning_count>` — informational; warnings annotate but do not block.
+- **Severity breakdown:** `<severity_breakdown>` — per-severity counts including info-level (e.g. `{"error": 0, "warning": 2, "info": 0}`). Surface this when relevant for triage.
+
 ## Context
 
 - **Spec version:** <from spec-manifest.txt>

--- a/propertyiq/skills/chart-qa/audit_via_rest.sh
+++ b/propertyiq/skills/chart-qa/audit_via_rest.sh
@@ -31,9 +31,10 @@
 #            even on non-zero exit, so the caller can introspect violations).
 #   stderr — diagnostic messages.
 #
-# Exit codes:
-#   0 — audit completed and passed:true (zero error-severity violations).
-#   1 — audit completed but passed:false (violations present).
+# Exit codes (per Tranche A.4 step 2 — derived from error_count):
+#   0 — audit completed with error_count == 0 (no error-severity violations).
+#       Warnings and info-level findings do NOT change the exit code.
+#   1 — audit completed with error_count > 0 (errors present).
 #   2 — request failed (HTTP error, bad input, network failure).
 #
 # Auth:
@@ -172,7 +173,24 @@ if [ -n "$OUTPUT_PATH" ]; then
     cp "$RESPONSE_FILE" "$OUTPUT_PATH"
 fi
 
-# Exit 0 iff passed:true. Anything else (including missing field) → 1.
+# Per Tranche A.4 step 2 of the chart-qa signal-restoration plan: exit
+# code derives from `error_count` rather than the deprecated `passed`
+# field. Behavior unchanged on the wire — charts-api A.4 step 1
+# (PR #297) ensures `passed == (error_count == 0)` by construction.
+# Fallback to `passed` handles older charts-api revisions and test
+# fixtures that haven't migrated yet; the fallback is removed in step 3.
+#
+# Exit codes:
+#   0 → error_count == 0 (no error-severity violations)
+#   1 → error_count > 0 (audit completed but errors present)
+ERROR_COUNT="$(jq -r '.error_count // empty' "$RESPONSE_FILE")"
+if [ -n "$ERROR_COUNT" ]; then
+    if [ "$ERROR_COUNT" = "0" ]; then
+        exit 0
+    fi
+    exit 1
+fi
+# Backward compat — older charts-api or test mocks without error_count.
 PASSED="$(jq -r '.passed // false' "$RESPONSE_FILE")"
 if [ "$PASSED" = "true" ]; then
     exit 0


### PR DESCRIPTION
## Summary
Per Tranche A.4 of the chart-qa signal-restoration plan: deprecate \`passed\` in favor of explicit per-severity fields. [charts-api PR #297](https://github.com/property-iq/propiq-charts-api/pull/297) shipped step 1 (additive fields). [reports-api PR #115](https://github.com/property-iq/propiq-reports-api/pull/115) migrated the two server-side consumers. This PR finishes step 2 by migrating the two skill-side consumers.

### Migrations
1. **\`audit_via_rest.sh\`** — exit code derived from \`error_count\` with fallback to legacy \`passed\` for older charts-api revisions / test mocks. Header docstring updated.
2. **\`SKILL.md\`** — output description lists \`error_count\` / \`warning_count\` / \`severity_breakdown\` as canonical; flags \`passed\` as deprecated.
3. **\`audit-finding-template.md\`** — new "Audit summary" section surfaces \`error_count\`, \`warning_count\`, \`severity_breakdown\` to reviewers in filed Issues.

### Backward compat
Bash fallback to legacy \`passed\` handles older charts-api revisions and test mocks. Removed in step 3.

### Verification
- Three bash test cases: contradicting (new field wins) and legacy (fallback) all produce expected exit codes.
- End-to-end against live charts-api revision \`-00385-hs2\`: clean audit returns \`error_count: 0\`, exit 0.
- \`shellcheck --severity=warning\` clean.

### Tracker (post-merge — Tranche A.4 step 2 fully done)
- ✅ \`validation.py\` (reports-api #115)
- ✅ \`agentic_visual_rendering.py\` (reports-api #115)
- ✅ \`audit_via_rest.sh\` (this PR)
- ✅ chart-qa \`SKILL.md\` + \`audit-finding-template.md\` (this PR)

Step 3 (deprecate \`passed\` from \`AuditResult\`) waits ≥30 days after step 2 stable in production.

## Test plan
- [x] Bash exit-code logic verified against three fixtures (new + legacy + contradicting)
- [x] Live charts-api E2E
- [x] \`shellcheck\` clean
- [ ] CI green (ShellCheck job + existing checks)