### PR TITLE
feat(chart-qa): SKILL rewrite for audit target selection, pacing, α envelope (Tranche G)

### DIFF
--- a/propertyiq/skills/chart-qa/SKILL.md
+++ b/propertyiq/skills/chart-qa/SKILL.md
@@ -12,9 +12,23 @@ PM has two audit paths. **Pick the one that matches the audit target**, not your
 |---|---|---|
 | **Single chart** with a known intent + entities | **REST first** (`audit_via_rest.sh`) | Sub-second when no vision needed; ~3–8s with vision. No screenshot, no Playwright. |
 | **Page** (rendered report or playground) with multiple charts in context | **Playwright + screenshots** (steps 1–3 below) | Catches surface-level issues: cross-chart layout, banners, console errors, viewport breakage. |
-| **Sweep** of N > 3 charts | **REST in parallel, async** (see "Sweep-mode dispatch" below) | Avoids serial round-trips; bundles findings into one Telegram summary. |
+| **Sweep** of N > 3 charts | **REST in parallel, async** (see "Pacing protocol → Sweep mode" below) | Avoids serial round-trips; bundles findings into one Telegram summary. |
 
 REST-first means: most single-chart audits skip the screenshot path entirely. Playwright is reserved for surface audits and Layer 2b vision review.
+
+## Audit target selection
+
+Pick the audit target deliberately. PM defaults are explicit; surface choice is a load-bearing decision because findings against different surfaces route differently and have different stability properties.
+
+| Target | When to use | Routing of findings |
+|---|---|---|
+| **Canonical fixtures** *(default once Tranche E lands)* | Baseline regression detection — the production-shaped chart requests `propiq-reports-api/app/generation/visual_rendering.py` actually emits | `propiq-charts-api` (runtime regression) or `propiq-docs` (spec lag), per drift classification |
+| **PageQA matrix** *(opt-in)* | Surface coverage — exhaustive variants generated from runtime capabilities, used by the visualizer | Tag findings with `surface=pageqa-only` and route to `propiq-visualizer` issues. PageQA generates variants that production never uses; findings only on the matrix are surface-level, not production defects |
+| **Latest rendered report** *(opt-in, never default)* | Report-specific QA when Martin asks about a specific report run | When used, name the report identifier explicitly in every reply (`market 2026-04`, etc.). Never elide the target — different runs have different defects |
+
+Until canonical fixtures (Tranche E) ship, the **default is the deterministic PageQA matrix snapshot** at the spec.yaml version current at audit time. Document the snapshot version in the audit reply so reviewers can correlate findings.
+
+**Why this matters.** The 2026-05-03 sweep transcript showed the agent anchoring on the latest rendered report by default — which means audit results were a function of which report had run most recently, not a stable basis for evaluation. The target selection above makes the basis explicit.
 
 ## Pre-audit: fetch the spec
 
@@ -50,18 +64,34 @@ The script's output is the `AuditResult` JSON: `error_count`, `warning_count`, `
 
 If the chart isn't already rendered (you have a `ChartRequest` rather than a `chart_response.config`), pass `render_request` and the API renders + audits in one round-trip.
 
-## Sweep-mode dispatch
+## Pacing protocol
 
-When auditing N > 3 charts (e.g. *"audit all charts in the April market report"*):
+The 2026-05-03 sweep transcript exposed PM leaking background-sweep summaries into Telegram while Martin had explicitly asked to proceed one-by-one. The bridge is purely reactive (it doesn't surface tool-completion events the agent didn't author); the discipline is fully agent-side. Pacing is not optional.
 
-1. **Acknowledge immediately on Telegram**: *"Auditing N charts; will report back when complete."*
+### One-by-one mode
+
+When Martin says *"one by one"*, *"one at a time"*, or any equivalent (the user is asking PM to pace itself):
+
+1. **Suspend any in-flight bulk sweep.** Do not start a new one.
+2. **Emit exactly one chart's audit result per turn.** Include `error_count`, `warning_count`, `audit_target`, layer breakdown.
+3. **Wait for explicit user advance** (*"next"*, *"continue"*, or equivalent). Do not advance autonomously.
+4. **Do not surface bulk-sweep summaries** in this mode, even if a background sweep completes. Surfacing background-completion events is what the 2026-05-03 transcript exposed; the bridge cannot suppress what PM emits.
+
+### Sweep mode
+
+When the request is a sweep (e.g. *"audit all charts in the April market report"*, N > 3 charts):
+
+1. **Acknowledge scope upfront.** *"Auditing N charts in [target]; will report back when complete."* Name the audit target (canonical fixtures / PageQA matrix / specific report).
 2. **Run audits in parallel**, bounded at 5 concurrent (matches `chart_concurrency` elsewhere in the stack). Use `xargs -P 5` or a small async wrapper.
-3. **Post a follow-up Telegram message** with a structured summary: per-chart pass/fail, per-layer counts, top violations. Don't surface findings in real time — batch them.
+3. **Post one consolidated summary at the end.** Per-chart `error_count` / `warning_count`, per-layer counts, top violations across the sweep. **Do not interleave per-chart findings during the sweep** — batch them.
 4. **For each chart with violations**, file Issues per the drift-classification mapping below.
 
-For ≤ 3 charts, dispatch synchronously and post findings inline.
-
+For ≤ 3 charts and not in one-by-one mode, dispatch synchronously and post findings inline.
 For single-chart audits where Martin needs sub-second turnaround, use `--no-vision`.
+
+### Mode disambiguation
+
+If Martin's request is ambiguous between one-by-one and sweep, **default to one-by-one and ask**: *"Sweep all N or proceed one at a time?"* Sweep mode commits to a longer turnaround; getting it wrong wastes time twice (sweep when one-by-one was wanted, or vice versa).
 
 ## Evaluation flow (page-level / surface audit / Layer 2b)
 
@@ -155,9 +185,49 @@ When the violation came from a screenshot evaluation (Playwright path), the lega
   - Screenshots from both viewports
 - **Audit aborted** (fetch failure, Playwright failure) — report verbatim to Martin.
 
+## Attaching chart images to replies (α envelope)
+
+When a finding warrants a rendered chart image (proof of a visual defect, before/after for Martin's review), emit images via the **α envelope** shape, not via path strings.
+
+### Do this
+
+When PM's reply includes images, the structured envelope is:
+
+```json
+{
+  "schema_version": "1",
+  "text": "<reply body — audit summary, findings, etc.>",
+  "attachments": [
+    {
+      "url": "<signed URL from render_chart_image>",
+      "content_type": "image/png",
+      "alt_text": "<chart title or '<metric> <intent> chart — <entities> — <viewport>'>",
+      "width": 1600,
+      "height": 1000
+    }
+  ]
+}
+```
+
+The OpenClaw → Telegram bridge consumes `attachments[]` and dispatches `sendPhoto` with `caption=alt_text` for image content types. Multiple attachments → one `sendPhoto` per entry. Non-image content types fall back to a labeled link in the text body.
+
+The signed URL comes from the `render_chart_image` MCP tool, which returns the envelope-shaped `attachments[]` field directly. Pass it through unchanged.
+
+### Do NOT do this
+
+**Never emit `MEDIA: /tmp/...png` strings in chat output.** That convention was an attempt to signal image attachment via in-band text, observed on 2026-05-03 leaving file paths in user-visible Telegram messages. The bridge does not parse `MEDIA:` strings and never will. The α envelope is the only protocol.
+
+PM does not write paths, file:// URIs, or inline image markup either. Image references are structured metadata in `attachments[]` or they don't exist.
+
+### During the deprecation window
+
+The bridge accepts both the legacy `{text, mediaUrls}` reply shape and the α envelope `{schema_version, text, attachments[]}` for one release cycle (per the OpenClaw α envelope spec, Conflict-4 resolution). PM emits the α envelope by default; the bridge falls back to its existing `mediaUrls` extraction for any legacy reply that doesn't include `attachments[]`. After the bridge's `OPENCLAW_DISPATCHER_ALPHA_ENVELOPE` flag flips on permanently and the `MEDIA:` smoke detector quiets, the legacy shape is deprecated.
+
 ## Boundaries
 
 - PM does not fix what it finds. PM files Issues or surfaces to Martin.
 - PM does not write to `propiq-docs/charts/`. Spec updates go through the normal pipeline (Issue → Refinement → design → build).
 - PM does not autonomously browse beyond the canonical surfaces.
 - When reporting a finding, cite the spec rule and paraphrase from `charts/guidelines.md` for human-readable rationale — never quote guidelines verbatim.
+- PM does not emit `MEDIA:` path strings in chat output (per α envelope section above). Image references are always structured metadata.
+- PM does not amplify background-sweep completion events into Telegram during one-by-one mode (per pacing protocol). Surfacing what Martin didn't ask for is the failure mode that motivates this section.

--- a/propertyiq/skills/chart-qa/audit-finding-template.md
+++ b/propertyiq/skills/chart-qa/audit-finding-template.md
@@ -23,6 +23,24 @@ Use this template for the Issue body when filing a chart-audit finding. Every fi
 - **Error count:** `<error_count>` — populated from `AuditResult.error_count` (Tranche A.4 step 1). Read this for blocking decisions; the deprecated `passed` flag is no longer load-bearing in this template.
 - **Warning count:** `<warning_count>` — informational; warnings annotate but do not block.
 - **Severity breakdown:** `<severity_breakdown>` — per-severity counts including info-level (e.g. `{"error": 0, "warning": 2, "info": 0}`). Surface this when relevant for triage.
+- **Dataset scope:** `<dataset_scope>` — the class of datasets the rule was evaluated against (`is_data` / `is_non_regression` / `is_regression` / `is_benchmark` / `all_datasets`). Per Tranche A.2, every rule declares its scope; surfacing this lets a reviewer see which subset the predicate iterated.
+
+## Audit target
+
+`<canonical fixtures | PageQA matrix | latest report (<grain>/<identifier>/<period>)>` — populated from the SKILL.md "Audit target selection" rule. Findings on PageQA-only variants are tagged `surface=pageqa-only` and route to `propiq-visualizer`; findings on canonical fixtures or production reports route per the drift-classification table. The audit target is a load-bearing context fact; never elide it.
+
+## Predicate behavior anomaly suspected
+
+_(populate this section only when the heuristic below fires; otherwise omit)_
+
+When a rule fires across **100% of canonical fixtures** in a sweep, that's a strong signal the predicate is misbehaving (matching too broadly), not that every chart in the corpus is genuinely defective. The 2026-05-03 sweep's I020 cluster — every scatter chart "failing" because the rule iterated over the regression line — is the prototype.
+
+If this finding is one of those:
+
+- **State the suspicion explicitly.** Don't file as a chart defect.
+- **Route to `propiq-charts-api`** as a predicate-bug Issue, not as a per-chart violation.
+- **Cite the firing rate** (e.g., "fires on 100% of canonical scatter fixtures").
+- Cross-reference the rule's `dataset_scope` declaration in `app/audit/rules/` for the reviewer.
 
 ## Context
 


### PR DESCRIPTION
## Summary
Per Tranche G of the chart-qa signal-restoration plan, rewrite the chart-qa skill to address the three failure modes the [2026-05-03 PageQA sweep transcript](../../working/design/propiq-charts-api_2026-05-05_chart-qa-signal-restoration-v3.md) exposed:

1. **Anchoring on the latest rendered report by default** — audit basis was unstable (a function of which report had run most recently)
2. **Leaking background-sweep completion summaries into Telegram** when Martin had explicitly asked to proceed one-by-one
3. **Emitting `MEDIA: /tmp/...png` strings in chat output** as if the bridge would parse them as image attachments

### G.1 — Audit target selection (new section)
Three explicit targets with when-to-use and routing:
- **Canonical fixtures** *(default once Tranche E lands)* — production-shaped requests from `visual_rendering.py`; route to charts-api or propiq-docs per drift classification
- **PageQA matrix** *(opt-in)* — exhaustive variants; findings tagged `surface=pageqa-only`, routed to propiq-visualizer
- **Latest report** *(opt-in, never default)* — name the report identifier in every reply

Until Tranche E lands, the default is the deterministic PageQA matrix snapshot at spec.yaml's current version.

### G.2 — Pacing protocol (replaces \"Sweep-mode dispatch\")
- **One-by-one mode:** suspend any in-flight sweep, emit exactly one chart per turn, wait for explicit advance. **Do not surface background-sweep completions** (the 2026-05-03 failure mode).
- **Sweep mode:** acknowledge scope upfront, parallel-bounded at 5, post one consolidated summary at the end. **Do not interleave** per-chart findings.
- **Mode disambiguation:** if ambiguous, default to one-by-one and ask.

### G.3 — α envelope adoption (new section)
Structured `{schema_version, text, attachments[]}` envelope consumed by the OpenClaw → Telegram bridge after C.3 lands. PM passes through the `attachments` array unchanged from `render_chart_image`'s MCP response. **`MEDIA:` strings explicitly forbidden** (three remaining mentions are all deprecation context).

During the deprecation window the bridge accepts both shapes; after `OPENCLAW_DISPATCHER_ALPHA_ENVELOPE` flips on permanently the legacy shape is dropped.

### G.4 — Audit-finding template extension
- `audit_target` field — canonical fixtures / PageQA / latest report; load-bearing context, never elide
- `dataset_scope` field — the class of datasets the rule was evaluated against (per Tranche A.2)
- **\"Predicate behavior anomaly suspected\" callout** — when a rule fires across 100% of canonical fixtures, route as predicate-bug Issue against charts-api, not per-chart violations. Prototype: 2026-05-03 I020 cluster.

## Test plan
- [x] \`shellcheck --severity=warning\` clean on \`audit_via_rest.sh\` and \`fetch_spec.sh\` (sanity check; no script changes)
- [x] All \`MEDIA:\` references in SKILL.md are deprecation-context only (verified by grep — lines 218, 224, 232)
- [x] Stale \"Sweep-mode dispatch\" anchor on line 15 updated to point at the new section
- [ ] CI green
- [ ] Post-merge: PM agent reads the rewritten skill on next session and operates per the new protocols

## Deferred
The structured-output CI gate proposed in v3 §G.2 (assert reply shape includes α envelope when chart-render intent is detected) requires an LLM in CI, which is expensive and out-of-scope for a prompt-only PR. Tracked for a future enhancement.